### PR TITLE
Fix the define used to distinguish MariaDB from Mysql

### DIFF
--- a/src/core-impl/storage/sql/mysql-shared/MySqlStorage.h
+++ b/src/core-impl/storage/sql/mysql-shared/MySqlStorage.h
@@ -29,7 +29,7 @@
   #include <winsock2.h>
 #endif
 
-#if !defined(MARIADB_VERSION_ID) && MYSQL_VERSION_ID >= 80000
+#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 80000
 using my_bool = bool;
 #endif
 


### PR DESCRIPTION
The correct define to distinguish MariaDB from MYSQL is MARIADB_BASE_VERSION according to their own commit:

https://github.com/mariadb-corporation/mariadb-connector-c/commit/7d6101d4f4ffc54e7cf4e7798d19b41d28571ec9