### PR TITLE
configurePhonon needs to display kcm_pulseaudio module not kcm_phonon

### DIFF
--- a/src/configdialog/dialogs/PlaybackConfig.cpp
+++ b/src/configdialog/dialogs/PlaybackConfig.cpp
@@ -88,7 +88,7 @@ PlaybackConfig::configurePhonon() //SLOT
     KCMultiDialog KCM;
 
     KCM.setWindowTitle( i18n( "Sound System - Amarok" ) );
-    KCM.addModule( QStringLiteral("kcm_phonon") );
+    KCM.addModule( QStringLiteral("kcm_pulseaudio") );
     KCM.exec();
 }
 


### PR DESCRIPTION
Configure Phonon was displaying an empty form - this fixes that issue.